### PR TITLE
Feat/get aaid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,14 @@
 {
     "name": "expo-linkrunner",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Expo Package for linkrunner.io",
     "main": "build/index.js",
     "types": "build/index.d.ts",
     "scripts": {
-        "build": "expo-module build",
-        "clean": "expo-module clean",
-        "lint": "expo-module lint",
-        "test": "expo-module test",
-        "_prepare": "expo-module prepare",
-        "prepublishOnly": "expo-module prepublishOnly",
-        "expo-module": "expo-module"
+        "build": "tsc",
+        "clean": "rm -rf build/",
+        "lint": "tsc --noEmit",
+        "prepublishOnly": "npm run clean && npm run build"
     },
     "keywords": [
         "expo",
@@ -39,7 +36,6 @@
     },
     "devDependencies": {
         "expo": "^52.0.37",
-        "expo-module-scripts": "^4.0.4",
         "typescript": "^5.7.3"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
     "main": "build/index.js",
     "types": "build/index.d.ts",
     "scripts": {
-        "build": "tsc",
-        "clean": "rm -rf build/",
-        "lint": "tsc --noEmit",
-        "prepublishOnly": "npm run clean && npm run build"
+        "build": "expo-module build",
+        "clean": "expo-module clean",
+        "lint": "expo-module lint",
+        "test": "expo-module test",
+        "_prepare": "expo-module prepare",
+        "prepublishOnly": "expo-module prepublishOnly",
+        "expo-module": "expo-module"
     },
     "keywords": [
         "expo",
@@ -36,6 +39,7 @@
     },
     "devDependencies": {
         "expo": "^52.0.37",
+        "expo-module-scripts": "^4.0.4",
         "typescript": "^5.7.3"
     },
     "peerDependencies": {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -63,7 +63,7 @@ const device_data = async (): Promise<Record<string, any>> => {
 
             // Advertising IDs with privacy controls
             idfa: Platform.OS === "ios" ? await getAdvertisingIdentifier() : null,
-            gaid: Platform.OS === "android" ? await safeGet(Application.getAndroidId) : null,
+            gaid: Platform.OS === "android" ? await getAdvertisingIdentifier() : null,
 
             // For IDFV, use dedicated function
             idfv: Platform.OS === "ios" ? await getIosIdentifierForVendor() : null,
@@ -103,6 +103,13 @@ const getAdvertisingIdentifier = async (): Promise<string | null> => {
             return null;
         } catch (error) {
             console.error("Error getting advertising identifier:", error);
+            return null;
+        }
+    } else if (Platform.OS === "android") {
+        try {
+            return await TrackingTransparency.getAdvertisingId();
+        } catch (error) {
+            console.error("Error getting Google Advertising ID:", error);
             return null;
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { device_data, getDeeplinkURL, getLinkRunnerInstallInstanceId, setDeeplin
 import type { CampaignData, UserData } from "./types";
 
 // Get package version
-const package_version = "2.0.2";
+const package_version = "2.0.3";
 const app_version = Application.nativeApplicationVersion || "";
 
 const baseUrl = "https://api.linkrunner.io";


### PR DESCRIPTION
- Added support to get gaid(aaid) for android devices
- No additional permissions are required for the changes to work, the `Expo TrackingTransparency` already has permissions in `AndroidManifest.xml` https://docs.expo.dev/versions/latest/sdk/tracking-transparency/#permissions