### PR TITLE
chore: version update for react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "expo-linkrunner",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "description": "Expo config plugin for rn-linkrunner SDK",
     "main": "build/index.js",
     "types": "build/index.d.ts",
@@ -48,7 +48,7 @@
     "peerDependencies": {
         "@expo/config-plugins": "^7.0.0 || ^8.0.0",
         "expo-tracking-transparency": "*",
-        "rn-linkrunner": "2.1.0"
+        "rn-linkrunner": "2.2.0"
     },
     "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "peerDependencies": {
         "@expo/config-plugins": "^7.0.0 || ^8.0.0",
         "expo-tracking-transparency": "*",
-        "rn-linkrunner": "2.2.0"
+        "rn-linkrunner": "^2.2.0"
     },
     "engines": {
         "node": ">=18.0.0"


### PR DESCRIPTION
bump version to 3.0.1 and update rn-linkrunner peer dependency to 2.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package version to 3.0.1.
  * Updated peer dependency for "rn-linkrunner" to version 2.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->