### PR TITLE
chore: add .npmignore and CHANGELOG.md files for project organization

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,62 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build outputs (keep build/ for distribution)
+# build/ is needed for the package
+
+# Source files (keep only built files)
+src/
+tsconfig.json
+
+# Development files
+.git/
+.gitignore
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+
+# Test files
+coverage/
+.nyc_output/
+test/
+tests/
+__tests__/
+
+# Environment files
+.env*
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs/
+*.log
+
+# Cache
+.cache/
+.temp/
+.tmp/
+
+# Expo specific
+app.config
+app.json
+app.plugin.js
+eas.json
+expo-module.config.json
+
+# Documentation (keep README.md)
+CLAUDE.md
+EXPO_INSTALLATION.md
+dependencies.txt
+
+# Old package files
+expo-linkrunner-*.tgz
+
+# Package lock (keep package.json)
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.2.1] - 2025-09-25
+
+### Added
+- Added `disableIdfa` configuration to the iOS plugin. When enabled, `NSUserTracking` is not added to the `Info.plist`, ensuring IDFA is not collected.
+
+### Removed
+- Removed `expo-tracking-transparency` from dependencies.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - iOS: Documented a new option to disable IDFA collection by omitting the tracking entry from app metadata.
- Documentation
  - Added a versioned CHANGELOG following Keep a Changelog and SemVer; recorded v3.2.1 notes.
- Chores
  - Added an .npmignore to prevent publishing development, build, test, and environment artifacts, while retaining necessary distribution assets and package-lock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->