### PR TITLE
chore: bump version to 3.3.0 and upgrade rn-linkrunner to version 2.6…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.3.0] - 2025-17-25
+## [3.3.0] - 2025-12-17
 
 - Upgraded `rn-linkrunner` version to support apple search ads attribution.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2025-17-25
+
+- Upgraded `rn-linkrunner` version to support apple search ads attribution.
+
 ## [3.2.1] - 2025-09-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "expo-linkrunner",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "expo-linkrunner",
-            "version": "3.2.1",
+            "version": "3.3.0",
             "license": "MIT",
             "dependencies": {
                 "@expo/config-plugins": "^5.0.4",
@@ -22,7 +22,7 @@
             },
             "peerDependencies": {
                 "@expo/config-plugins": "^7.0.0 || ^8.0.0",
-                "rn-linkrunner": "^2.4.2"
+                "rn-linkrunner": "^2.6.0"
             }
         },
         "node_modules/@0no-co/graphql.web": {
@@ -12901,9 +12901,9 @@
             }
         },
         "node_modules/rn-linkrunner": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/rn-linkrunner/-/rn-linkrunner-2.4.2.tgz",
-            "integrity": "sha512-0+OBZVtzH6b7Bb69UKnbCnUT/EBJTt13LLZf7OXjVLYsffssCMPM/uKyaXl+xo9KhgCVoAv/LPe9LLV+607bWQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/rn-linkrunner/-/rn-linkrunner-2.6.0.tgz",
+            "integrity": "sha512-RpAPK+KNtWN5kkGeDXPHY0lajl965jHMBR+beF6ckZeynB97QIFoFKqlSE/JmkWHozcIAWl5lMlhRoD5ZIkW0Q==",
             "license": "MIT",
             "peer": true,
             "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "expo-linkrunner",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "description": "Expo config plugin for rn-linkrunner SDK",
     "main": "build/index.js",
     "types": "build/index.d.ts",
@@ -47,7 +47,7 @@
     },
     "peerDependencies": {
         "@expo/config-plugins": "^7.0.0 || ^8.0.0",
-        "rn-linkrunner": "^2.4.2"
+        "rn-linkrunner": "^2.6.0"
     },
     "engines": {
         "node": ">=18.0.0"


### PR DESCRIPTION
….0 for Apple Search Ads attribution support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package version to 3.3.0.
  * Upgraded rn-linkrunner peer dependency to ^2.6.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->