### PR TITLE
Meta event manager - changed version for meta expo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-02-24
+
+### Added
+
+- Added support for passing `eventData` in the `capturePayment` method for Meta event manager integration.
+
 ## [3.3.0] - 2025-12-17
 
 - Upgraded `rn-linkrunner` version to support apple search ads attribution.
@@ -12,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.2.1] - 2025-09-25
 
 ### Added
+
 - Added `disableIdfa` configuration to the iOS plugin. When enabled, `NSUserTracking` is not added to the `Info.plist`, ensuring IDFA is not collected.
 
 ### Removed
+
 - Removed `expo-tracking-transparency` from dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "expo-linkrunner",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "description": "Expo config plugin for rn-linkrunner SDK",
     "main": "build/index.js",
     "types": "build/index.d.ts",
@@ -47,7 +47,7 @@
     },
     "peerDependencies": {
         "@expo/config-plugins": "^7.0.0 || ^8.0.0",
-        "rn-linkrunner": "^2.6.0"
+        "rn-linkrunner": "^2.7.0"
     },
     "engines": {
         "node": ">=18.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing eventData in the capturePayment method for Meta event manager integration
  * Added disableIdfa configuration option for iOS plugin to control data collection

* **Dependencies**
  * Updated rn-linkrunner peer dependency requirement to ^2.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->