### PR TITLE
chore: bump to 3.4.0 and upgrade rn-linkrunner to ^3.1.0 [LIN-2078]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-07-27
+
+- Upgraded `rn-linkrunner` to `^3.1.0`, adding support for Google Integrated Conversion Measurement (ICM).
+- This crosses a major version of `rn-linkrunner`: the previous `^2.6.0` range could not resolve the 3.x line, so Expo had been holding at 2.x. Review the `rn-linkrunner` 3.0.0 notes when upgrading.
+- iOS builds now pull `GoogleAdsOnDeviceConversion` transitively. Verify that `expo prebuild` resolves it and that `-ObjC` and `-lc++` reach your app target.
+
 ## [3.3.0] - 2025-12-17
 
 - Upgraded `rn-linkrunner` version to support apple search ads attribution.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "expo-linkrunner",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "description": "Expo config plugin for rn-linkrunner SDK",
     "main": "build/index.js",
     "types": "build/index.d.ts",
@@ -47,7 +47,7 @@
     },
     "peerDependencies": {
         "@expo/config-plugins": "^7.0.0 || ^8.0.0",
-        "rn-linkrunner": "^2.6.0"
+        "rn-linkrunner": "^3.1.0"
     },
     "engines": {
         "node": ">=18.0.0"


### PR DESCRIPTION
Picks up Google Integrated Conversion Measurement support via `rn-linkrunner`. **3.3.0 → 3.4.0.**

## This crosses a major version of rn-linkrunner

The previous range was `^2.6.0`, which **cannot resolve the 3.x line** — caret ranges don't cross majors. Expo has therefore been holding at 2.x while `rn-linkrunner` shipped 3.0.0 and 3.0.1. Bumping to `^3.1.0` picks up ICM *and* clears that latent staleness.

Please review the `rn-linkrunner` 3.0.0 notes for anything the config plugin depends on.

## iOS dependency

Builds now pull `GoogleAdsOnDeviceConversion` (plus `GoogleUtilities` and `nanopb`) transitively. Verify that `expo prebuild` resolves it in both the managed and bare workflows, and that `-ObjC` and `-lc++` reach the app target.

## Known gap

Google Ads consent isn't yet exposed through the JavaScript bridge in `rn-linkrunner`, so consent is reported as `unknown`. Google treats that as "not known" rather than granted — safe, but incomplete for EEA traffic, which is precisely where ICM applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)